### PR TITLE
Chore/not/remove objective

### DIFF
--- a/src/l10n/helptexts.nb.js
+++ b/src/l10n/helptexts.nb.js
@@ -17,10 +17,6 @@ Se spesifikasjonen <a href='https://data.norge.no/specification/dcat-ap-no/#Data
 
 Se spesifikasjonen <a href='https://data.norge.no/specification/dcat-ap-no/#Datasett-beskrivelse' target='_blank'><span>Datasett: beskrivelse</span><i class="fa fa-external-link fdk-fa-right"></i></a>`
   },
-  Dataset_objective: {
-    abstract: 'Oppsummer formålet i én setning.',
-    description: `Hvis datasettet inneholder personopplysninger må formålet med dette oppgis.`
-  },
   Dataset_spatial: {
     abstract:
       'Dersom datasettet kun har innhold fra visse geografiske områder angis dette med lenke til Administrative enheter fra Kartverket eller GeoNames.',

--- a/src/l10n/nb.json
+++ b/src/l10n/nb.json
@@ -176,12 +176,10 @@
       "helptext": {
         "title": "Tittel",
         "description": "Beskrivelse av datasettet",
-        "objective": "Formålet med datasettet",
         "landingPage": "Lenke til mer informasjon om datasettet"
       },
       "titleLabel": "Tittel",
-      "descriptionLabel": "Beskrivelse",
-      "objectiveLabel": "Formål"
+      "descriptionLabel": "Beskrivelse"
     },
     "accessRights": {
       "heading": "Tilgangsnivå",

--- a/src/mock/datasets.response.json
+++ b/src/mock/datasets.response.json
@@ -6,7 +6,6 @@
         "uri": "http://brreg.no/catalogs/910258028/datasets/c536ddb2-1133-4443-96d1-ef0445d43543",
         "title": {},
         "description": {},
-        "objective": {},
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
           "name": "LILAND OG ERDAL REVISJON"
@@ -24,7 +23,6 @@
         "description": {
           "nb": "Når testdirektøren er på fest, danser..."
         },
-        "objective": {},
         "keyword": [],
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -132,7 +130,6 @@
         "description": {
           "nb": "to"
         },
-        "objective": {},
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
           "name": "LILAND OG ERDAL REVISJON"
@@ -180,7 +177,6 @@
         "description": {
           "nb": "En samling av navneendringer på statlige eide foretak.   \nHer er dagens ekstra tekst"
         },
-        "objective": {},
         "contactPoint": [
           {
             "email": "mail@mail.no",
@@ -538,7 +534,6 @@
           "nb": "Dette er norsk",
           "en": "This is english"
         },
-        "objective": {},
         "keyword": [],
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -654,9 +649,6 @@
         "description": {
           "nb": "Servieedition bugfix testen"
         },
-        "objective": {
-          "nb": "test "
-        },
         "keyword": [
           {
             "nb": "tullogtøys"
@@ -760,9 +752,6 @@
           "nb": "Oppfølger til Ut mot havet",
           "nn": "Oppfølgjer"
         },
-        "objective": {
-          "nb": ""
-        },
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
           "name": "LILAND OG ERDAL REVISJON"
@@ -818,9 +807,6 @@
         },
         "description": {
           "nb": "En historisk oversikt"
-        },
-        "objective": {
-          "nb": "Hvem satt på tinget når?..."
         },
         "keyword": [
           {
@@ -1005,7 +991,6 @@
         "description": {
           "nb": "En oversikt over midtbanespillere som Kante, Fabinho, Dunga, Makelele, Skammelsrud"
         },
-        "objective": {},
         "keyword": [],
         "publisher": {
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -1112,9 +1097,6 @@
         },
         "description": {
           "nb": "En litt lang beskrivelse som skal vise  at dette er litt mer utførlig test av regresjonsløsningen etter at det er utført en litt større refaktorering"
-        },
-        "objective": {
-          "nb": "Forsatt er formålet utstrakt test av "
         },
         "contactPoint": [
           {
@@ -1742,9 +1724,6 @@
         },
         "description": {
           "nb": "Dette er en hyllest av Rune Rudberg."
-        },
-        "objective": {
-          "nb": "Det finnes ikke noe formål."
         },
         "contactPoint": [
           {

--- a/src/pages/dataset-list-page/__fixtures/datasets.js
+++ b/src/pages/dataset-list-page/__fixtures/datasets.js
@@ -11,9 +11,6 @@ export default {
         description: {
           nb: 'tester'
         },
-        objective: {
-          nb: ''
-        },
         publisher: {
           uri: 'http://data.brreg.no/enhetsregisteret/enhet/910244132',
           name: 'RAMSUND OG ROGNAN REVISJON'

--- a/src/pages/dataset-list-page/items-list/__snapshots__/dataset-items-list.test.jsx.snap
+++ b/src/pages/dataset-list-page/items-list/__snapshots__/dataset-items-list.test.jsx.snap
@@ -16,7 +16,6 @@ exports[`should render DatasetItemsList correctly with datasetItems 1`] = `
         "catalogId": "910258028",
         "description": Object {},
         "id": "c536ddb2-1133-4443-96d1-ef0445d43543",
-        "objective": Object {},
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -100,7 +99,6 @@ exports[`should render DatasetItemsList correctly with datasetItems 1`] = `
             "uri": "",
           },
         ],
-        "objective": Object {},
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -165,7 +163,6 @@ exports[`should render DatasetItemsList correctly with datasetItems 1`] = `
             "uri": "",
           },
         ],
-        "objective": Object {},
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -439,7 +436,6 @@ Her er dagens ekstra tekst",
           },
         ],
         "modified": "2019-04-03T22:00:00.000+0000",
-        "objective": Object {},
         "provenance": Object {
           "code": "BRUKER",
           "prefLabel": Object {
@@ -630,7 +626,6 @@ Her er dagens ekstra tekst",
             "uri": "",
           },
         ],
-        "objective": Object {},
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -736,9 +731,6 @@ Her er dagens ekstra tekst",
             "uri": "",
           },
         ],
-        "objective": Object {
-          "nb": "test ",
-        },
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -800,9 +792,6 @@ Her er dagens ekstra tekst",
             "uri": "https://vg.no",
           },
         ],
-        "objective": Object {
-          "nb": "",
-        },
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -944,9 +933,6 @@ Her er dagens ekstra tekst",
           },
         ],
         "modified": "2019-12-02T00:00:00.000+0000",
-        "objective": Object {
-          "nb": "Hvem satt på tinget når?...",
-        },
         "provenance": Object {
           "code": "VEDTAK",
           "prefLabel": Object {
@@ -1082,7 +1068,6 @@ Her er dagens ekstra tekst",
             "uri": "",
           },
         ],
-        "objective": Object {},
         "publisher": Object {
           "name": "LILAND OG ERDAL REVISJON",
           "uri": "https://data.brreg.no/enhetsregisteret/api/enheter/910258028",
@@ -1579,9 +1564,6 @@ Her er dagens ekstra tekst",
           },
         ],
         "modified": "2019-05-31T22:00:00.000+0000",
-        "objective": Object {
-          "nb": "Forsatt er formålet utstrakt test av ",
-        },
         "provenance": Object {
           "code": "BRUKER",
           "prefLabel": Object {
@@ -1937,9 +1919,6 @@ Her er dagens ekstra tekst",
           },
         ],
         "modified": "2019-11-27T00:00:00.000+0000",
-        "objective": Object {
-          "nb": "Det finnes ikke noe formål.",
-        },
         "provenance": Object {
           "code": "TREDJEPART",
           "prefLabel": Object {

--- a/src/pages/dataset-registration-page/dataset-registration-page-pure.tsx
+++ b/src/pages/dataset-registration-page/dataset-registration-page-pure.tsx
@@ -153,7 +153,6 @@ export const DatasetRegistrationPagePure: FC<DatasetRegistrationPagePureProps> =
   const translatableFields = [
     'title',
     'description',
-    'objective',
     'legalBasisForRestriction',
     'legalBasisForProcessing',
     'legalBasisForAccess',

--- a/src/pages/dataset-registration-page/dataset-registration-page.logic.js
+++ b/src/pages/dataset-registration-page/dataset-registration-page.logic.js
@@ -7,14 +7,11 @@ import { getTranslateText } from '../../services/translateText';
 export const titleValues = values => {
   if (values) {
     let retVal = '';
-    const { title, description, objective, landingPage } = values;
+    const { title, description, landingPage } = values;
 
     retVal += getTranslateText(title) ? `${getTranslateText(title)}. ` : '';
     retVal += getTranslateText(description)
       ? `${getTranslateText(description)}. `
-      : '';
-    retVal += getTranslateText(objective)
-      ? `${getTranslateText(objective)}. `
       : '';
     retVal += _.get(landingPage, '[0]', '');
 

--- a/src/pages/dataset-registration-page/form-title/__snapshots__/form-title.test.jsx.snap
+++ b/src/pages/dataset-registration-page/form-title/__snapshots__/form-title.test.jsx.snap
@@ -38,22 +38,6 @@ exports[`should render FormTitle, { renderLandingpage  correctly 1`] = `
     className="form-group"
   >
     <withStateHandlers(HelpTextPure)
-      required={true}
-      term="Dataset_objective"
-      title="Formålet med datasettet"
-    />
-    <MultilingualField
-      component={[Function]}
-      label="Formål"
-      languages={Array []}
-      name="objective"
-      showLabel={false}
-    />
-  </div>
-  <div
-    className="form-group"
-  >
-    <withStateHandlers(HelpTextPure)
       term="Dataset_landingpage"
       title="Lenke til mer informasjon om datasettet"
     />

--- a/src/pages/dataset-registration-page/form-title/connected-form-title.component.jsx
+++ b/src/pages/dataset-registration-page/form-title/connected-form-title.component.jsx
@@ -9,7 +9,6 @@ const mapStateToProps = (state, { datasetItem = {} }) => ({
   initialValues: {
     title: datasetItem.title || {},
     description: datasetItem.description || {},
-    objective: datasetItem.objective || {},
     landingPage: _.get(datasetItem, 'landingPage', emptyArray)
   },
   syncErrors: getFormSyncErrors('title')(state)

--- a/src/pages/dataset-registration-page/form-title/form-title.component.jsx
+++ b/src/pages/dataset-registration-page/form-title/form-title.component.jsx
@@ -51,19 +51,6 @@ export const FormTitle = ({ languages, isReadOnly }) => (
         label={localization.schema.title.descriptionLabel}
       />
     </div>
-    <div className="form-group">
-      <Helptext
-        title={localization.schema.title.helptext.objective}
-        term="Dataset_objective"
-        required
-      />
-      <MultilingualField
-        name="objective"
-        component={isReadOnly ? InputFieldReadonly : TextAreaField}
-        label={localization.schema.title.objectiveLabel}
-        languages={languages}
-      />
-    </div>
 
     <div className="form-group">
       <Helptext

--- a/src/pages/dataset-registration-page/form-title/form-title.validations.js
+++ b/src/pages/dataset-registration-page/form-title/form-title.validations.js
@@ -83,45 +83,7 @@ export const schema = Yup.object().shape({
   }),
   landingPage: Yup.array().of(
     Yup.string().url(localization.validation.validateLink)
-  ),
-  objective: Yup.object().shape({
-    nb: Yup.string()
-      .nullable()
-      .test(function () {
-        const { nb, nn, en } = this.parent;
-        if (!nb && !nn && !en) {
-          return this.createError({
-            message: localization.validation.required,
-            path: this.path
-          });
-        }
-        return true;
-      }),
-    nn: Yup.string()
-      .nullable()
-      .test(function () {
-        const { nb, nn, en } = this.parent;
-        if (!nb && !nn && !en) {
-          return this.createError({
-            message: localization.validation.required,
-            path: this.path
-          });
-        }
-        return true;
-      }),
-    en: Yup.string()
-      .nullable()
-      .test(function () {
-        const { nb, nn, en } = this.parent;
-        if (!nb && !nn && !en) {
-          return this.createError({
-            message: localization.validation.required,
-            path: this.path
-          });
-        }
-        return true;
-      })
-  })
+  )
 });
 
 /* eslint-enable func-names */

--- a/src/types/domain.d.ts
+++ b/src/types/domain.d.ts
@@ -58,7 +58,6 @@ export interface Dataset {
   title: Record<string, string>;
   description: Record<string, string>;
   descriptionFormatted: Record<string, string>;
-  objective: Record<string, string>;
   contactPoint: Contact[];
   keyword: Record<string, string>[];
   publisher: Publisher;


### PR DESCRIPTION
Må fjerne `objective` pga dcat-ap-no 2.0. Starter med å skjule objective her i frontend og tar en ETL med @valosnah, vi legger innholdet fra objective til som en del av description.

Frontend etter dette:
![Screenshot from 2021-04-22 13-37-17](https://user-images.githubusercontent.com/50194012/115710356-8b15e800-a372-11eb-8338-d98aad35165f.png)
