### PR TITLE
fix: #219 Correcting text label

### DIFF
--- a/src/l10n/nb.json
+++ b/src/l10n/nb.json
@@ -170,7 +170,8 @@
       "helptext": {
         "title": "Innholdsleverandører"
       },
-      "searchOrgNr": "Søk på organisasjonsnummer"
+      "searchOrgNr": "Søk på organisasjonsnummer",
+      "searchOrg": "Søk på organisasjon"
     },
     "title": {
       "helptext": {

--- a/src/pages/dataset-registration-page/form-qualifiedAttributions/form-qualified-attributions.component.tsx
+++ b/src/pages/dataset-registration-page/form-qualifiedAttributions/form-qualified-attributions.component.tsx
@@ -66,7 +66,7 @@ const FormQualifiedAttributionsPure: FC<Props> = ({
       />
       {!isReadOnly && (
         <label className="fdk-form-label mb-2" htmlFor="publisher">
-          {localization.schema.qualifiedAttributions.searchOrgNr}
+          {localization.schema.qualifiedAttributions.searchOrg}
         </label>
       )}
       <div className="d-flex">


### PR DESCRIPTION
En liten fiks som retter på teksten på søkefeltet til organisasjon