### PR TITLE
fix: #219 Correcting text label

### DIFF
--- a/src/l10n/nb.json
+++ b/src/l10n/nb.json
@@ -171,7 +171,7 @@
         "title": "Innholdsleverandører"
       },
       "searchOrgNr": "Søk på organisasjonsnummer",
-      "searchOrg": "Søk på organisasjon"
+      "searchOrg": "Søk på organisasjonsnavn eller oppgi organisasjonsnummer"
     },
     "title": {
       "helptext": {


### PR DESCRIPTION
Ny PR på ordlyden på tekstfeltet for søk på organisasjon. Jeg hadde misforstått hvilken ordlyd vi ble enige om. Dette er den riktige 